### PR TITLE
Fix NotificationAdapter to send fake emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # pet-care-schedule
+
+## Local fake email server
+
+To capture reminder notifications during development a MailHog container is
+provided. Start it with:
+
+```bash
+docker compose up -d mailhog
+```
+
+MailHog exposes the SMTP service on `localhost:1025` and a web UI on
+`http://localhost:8025` where all sent mails can be inspected.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/notification/NotificationAdapter.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/notification/NotificationAdapter.kt
@@ -1,13 +1,26 @@
-package dev.vilquer.petcarescheduler.dev.vilquer.petcarescheduler.infra.adapter.output.notification
+package dev.vilquer.petcarescheduler.infra.adapter.output.notification
 
 import dev.vilquer.petcarescheduler.core.domain.entity.Event
 import dev.vilquer.petcarescheduler.usecase.contract.drivenports.NotificationPort
-import org.hibernate.query.sqm.tree.SqmNode.log
+import org.slf4j.LoggerFactory
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
 
 @Component
-class LogNotificationAdapter : NotificationPort {
+class EmailNotificationAdapter(
+    private val mailSender: JavaMailSender
+) : NotificationPort {
+
+    private val log = LoggerFactory.getLogger(EmailNotificationAdapter::class.java)
+
     override fun sendEventReminder(event: Event) {
-        log.info("Sending event: $event")
+        val message = mailSender.createMimeMessage()
+        val helper = MimeMessageHelper(message)
+        helper.setTo("test@example.com")
+        helper.setSubject("PetCareScheduler reminder")
+        helper.setText("Event ${'$'}{event.type} on ${'$'}{event.dateStart}: ${'$'}{event.description}")
+        mailSender.send(message)
+        log.info("Sent fake mail for event {}", event.id)
     }
 }

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -17,3 +17,7 @@ spring:
     console:
       enabled: true
       path: /h2-console
+
+  mail:
+    host: localhost
+    port: 1025


### PR DESCRIPTION
## Summary
- create an EmailNotificationAdapter that sends mail using JavaMailSender
- configure Spring Mail to use localhost
- document how to run MailHog in README
- add docker-compose with MailHog service for local testing

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6873329c4c2c8332b40276fafeb56141