### PR TITLE
Add tests for application services and controllers

### DIFF
--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/TestDoubles.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/TestDoubles.kt
@@ -1,0 +1,62 @@
+package dev.vilquer.petcarescheduler.application
+
+import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.usecase.contract.drivenports.*
+import java.time.ZonedDateTime
+
+internal class FakeClock(var fixed: ZonedDateTime) : ClockPort {
+    override fun now(): ZonedDateTime = fixed
+}
+
+internal class FakeNotifier : NotificationPort {
+    val notified = mutableListOf<Event>()
+    override fun sendEventReminder(event: Event) { notified.add(event) }
+}
+
+internal class InMemoryTutorRepo(initial: Map<TutorId, Tutor> = emptyMap()) : TutorRepositoryPort {
+    private val store = LinkedHashMap<TutorId, Tutor>().apply { putAll(initial) }
+    private var seq = (store.keys.map { it.value }.maxOrNull() ?: 0L) + 1
+    override fun save(tutor: Tutor): Tutor {
+        val id = tutor.id ?: TutorId(seq++)
+        val saved = tutor.copy(id = id)
+        store[id] = saved
+        return saved
+    }
+    override fun findById(id: TutorId): Tutor? = store[id]
+    override fun findAll(page: Int, size: Int): List<Tutor> =
+        store.values.drop(page * size).take(size)
+    override fun countAll(): Long = store.size.toLong()
+    override fun delete(id: TutorId) { store.remove(id) }
+}
+
+internal class InMemoryPetRepo(initial: Map<PetId, Pet> = emptyMap()) : PetRepositoryPort {
+    private val store = LinkedHashMap<PetId, Pet>().apply { putAll(initial) }
+    private var seq = (store.keys.map { it.value }.maxOrNull() ?: 0L) + 1
+    override fun save(pet: Pet): Pet {
+        val id = pet.id ?: PetId(seq++)
+        val saved = pet.copy(id = id)
+        store[id] = saved
+        return saved
+    }
+    override fun findById(id: PetId): Pet? = store[id]
+    override fun delete(id: PetId) { store.remove(id) }
+    override fun findAll(page: Int, size: Int): List<Pet> =
+        store.values.drop(page * size).take(size)
+    override fun countAll(): Long = store.size.toLong()
+}
+
+internal class InMemoryEventRepo(initial: Map<EventId, Event> = emptyMap()) : EventRepositoryPort {
+    private val store = LinkedHashMap<EventId, Event>().apply { putAll(initial) }
+    private var seq = (store.keys.map { it.value }.maxOrNull() ?: 0L) + 1
+    override fun save(event: Event): Event {
+        val id = event.id ?: EventId(seq++)
+        val saved = event.copy(id = id)
+        store[id] = saved
+        return saved
+    }
+    override fun findById(id: EventId): Event? = store[id]
+    override fun findByPetId(petId: PetId): List<Event> =
+        store.values.filter { it.petId == petId }
+
+    fun allEvents(): Collection<Event> = store.values
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/EventControllerTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/EventControllerTest.kt
@@ -1,0 +1,40 @@
+package dev.vilquer.petcarescheduler.application.adapter.input.rest
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.vilquer.petcarescheduler.application.mapper.EventDtoMapper
+import dev.vilquer.petcarescheduler.application.service.EventAppService
+import dev.vilquer.petcarescheduler.core.domain.entity.EventId
+import dev.vilquer.petcarescheduler.usecase.result.EventRegisteredResult
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class EventControllerTest {
+    private val service: EventAppService = mock(EventAppService::class.java)
+    private val mapper: EventDtoMapper = object : EventDtoMapper {}
+    private lateinit var mvc: MockMvc
+    private val objectMapper = jacksonObjectMapper()
+
+    @BeforeEach
+    fun setup() {
+        mvc = MockMvcBuilders.standaloneSetup(EventController(service, mapper)).build()
+    }
+
+    @Test
+    fun `register returns 201`() {
+        `when`(service.registerEvent(any())).thenReturn(EventRegisteredResult(EventId(2)))
+        val req = EventDtoMapper.RegisterRequest(1,"SERVICE","desc","2025-07-01T10:00:00Z")
+
+        mvc.perform(post("/api/v1/events")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.eventId").value(2))
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/PetControllerTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/PetControllerTest.kt
@@ -1,0 +1,65 @@
+package dev.vilquer.petcarescheduler.application.adapter.input.rest
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.vilquer.petcarescheduler.application.mapper.PetDtoMapper
+import dev.vilquer.petcarescheduler.application.service.PetAppService
+import dev.vilquer.petcarescheduler.core.domain.entity.PetId
+import dev.vilquer.petcarescheduler.usecase.command.DeletePetCommand
+import dev.vilquer.petcarescheduler.usecase.result.PetCreatedResult
+import dev.vilquer.petcarescheduler.usecase.result.PetsPageResult
+import dev.vilquer.petcarescheduler.usecase.result.PetSummary
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.ArgumentCaptor
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class PetControllerTest {
+    private val service: PetAppService = mock(PetAppService::class.java)
+    private val mapper: PetDtoMapper = object : PetDtoMapper {}
+    private lateinit var mvc: MockMvc
+    private val objectMapper = jacksonObjectMapper()
+
+    @BeforeEach
+    fun setup() {
+        mvc = MockMvcBuilders.standaloneSetup(PetController(service, mapper)).build()
+    }
+
+    @Test
+    fun `create pet returns 201`() {
+        `when`(service.createPet(any())).thenReturn(PetCreatedResult(PetId(5)))
+        val req = PetDtoMapper.CreateRequest("Rex","Dog",null,"2020-01-01",1)
+
+        mvc.perform(post("/api/v1/pets")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.petId").value(5))
+    }
+
+    @Test
+    fun `list pets returns page`() {
+        val page = PetsPageResult(listOf(PetSummary(PetId(1),"Rex","Dog")),1,0,20)
+        `when`(service.listPets(0,20)).thenReturn(page)
+
+        mvc.perform(get("/api/v1/pets"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].id").value(1))
+    }
+
+    @Test
+    fun `delete pet delegates to service`() {
+        val captor = ArgumentCaptor.forClass(DeletePetCommand::class.java)
+        doNothing().`when`(service).deletePet(captor.capture())
+
+        mvc.perform(delete("/api/v1/pets/3"))
+            .andExpect(status().isNoContent)
+
+        verify(service).deletePet(any())
+        assert(PetId(3) == captor.value.petId)
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorControllerTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorControllerTest.kt
@@ -1,0 +1,51 @@
+package dev.vilquer.petcarescheduler.application.adapter.input.rest
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.vilquer.petcarescheduler.application.mapper.TutorDtoMapper
+import dev.vilquer.petcarescheduler.application.service.TutorAppService
+import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.usecase.result.TutorCreatedResult
+import dev.vilquer.petcarescheduler.usecase.result.TutorSummary
+import dev.vilquer.petcarescheduler.usecase.result.TutorsPageResult
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class TutorControllerTest {
+    private val service: TutorAppService = mock(TutorAppService::class.java)
+    private val mapper: TutorDtoMapper = object : TutorDtoMapper {}
+    private lateinit var mvc: MockMvc
+    private val objectMapper = jacksonObjectMapper()
+
+    @BeforeEach
+    fun setup() {
+        mvc = MockMvcBuilders.standaloneSetup(TutorController(service, mapper)).build()
+    }
+
+    @Test
+    fun `create tutor returns 201`() {
+        `when`(service.createTutor(any())).thenReturn(TutorCreatedResult(TutorId(1)))
+        val req = TutorDtoMapper.CreateRequest("Ana", null, "a@e.com", "pwd", "1", null)
+
+        mvc.perform(post("/api/v1/tutors")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.tutorId").value(1))
+    }
+
+    @Test
+    fun `list tutors returns page`() {
+        val page = TutorsPageResult(listOf(TutorSummary(TutorId(1),"Ana","a@e.com",0)),1,0,20)
+        `when`(service.listTutors(0,20)).thenReturn(page)
+
+        mvc.perform(get("/api/v1/tutors"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].id").value(1))
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/scheduler/EventReminderSchedulerTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/scheduler/EventReminderSchedulerTest.kt
@@ -1,0 +1,16 @@
+package dev.vilquer.petcarescheduler.application.adapter.input.scheduler
+
+import dev.vilquer.petcarescheduler.application.service.EventAppService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+
+class EventReminderSchedulerTest {
+    private val service: EventAppService = mock(EventAppService::class.java)
+    private val scheduler = EventReminderScheduler(service)
+
+    @Test
+    fun `scheduler delegates to service`() {
+        scheduler.sendDailyReminders()
+        verify(service).sendRemindersForToday()
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/EventAppServiceTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/EventAppServiceTest.kt
@@ -1,0 +1,66 @@
+package dev.vilquer.petcarescheduler.application.service
+
+import dev.vilquer.petcarescheduler.application.*
+import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.usecase.command.DeleteEventCommand
+import dev.vilquer.petcarescheduler.usecase.command.RegisterEventCommand
+import dev.vilquer.petcarescheduler.usecase.result.EventRegisteredResult
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class EventAppServiceTest {
+
+    private val petRepo = InMemoryPetRepo()
+    private val eventRepo = InMemoryEventRepo()
+    private val clock = FakeClock(ZonedDateTime.of(LocalDateTime.of(2025,7,1,8,0), ZoneId.systemDefault()))
+    private val notifier = FakeNotifier()
+    private val service = EventAppService(eventRepo, petRepo, clock, notifier)
+
+    @Test
+    fun `registerEvent should throw when pet does not exist`() {
+        val cmd = RegisterEventCommand(PetId(1), EventType.VACCINE, "vac", LocalDateTime.now())
+        assertThrows(IllegalArgumentException::class.java) { service.registerEvent(cmd) }
+    }
+
+    @Test
+    fun `registerEvent persists event and notifies`() {
+        val pet = petRepo.save(Pet(id = PetId(1), name="rex", specie="dog", race=null, birthdate= LocalDate.now(), tutorId = TutorId(1)))
+        val cmd = RegisterEventCommand(pet.id!!, EventType.SERVICE, "bath", LocalDateTime.of(2025,7,2,9,0))
+
+        val result: EventRegisteredResult = service.registerEvent(cmd)
+
+        assertEquals(EventId(1), result.eventId)
+        val saved = eventRepo.findById(result.eventId)
+        assertEquals(Status.PENDING, saved?.status)
+        assertEquals(1, notifier.notified.size)
+        assertEquals(saved, notifier.notified.first())
+    }
+
+    @Test
+    fun `deleteEvent marks event done`() {
+        val pet = petRepo.save(Pet(id = PetId(1), name="rex", specie="dog", race=null, birthdate= LocalDate.now(), tutorId = TutorId(1)))
+        val ev = eventRepo.save(Event(type=EventType.DIARY, description=null, dateStart=LocalDateTime.now(), recurrence=null, status=Status.PENDING, petId=pet.id!!))
+        service.deleteEvent(DeleteEventCommand(ev.id!!))
+        val updated = eventRepo.findById(ev.id!!)
+        assertEquals(Status.DONE, updated?.status)
+    }
+
+    @Test
+    fun `sendRemindersForToday notifies only today's pending events`() {
+        val pet = petRepo.save(Pet(id = PetId(1), name="rex", specie="dog", race=null, birthdate= LocalDate.now(), tutorId = TutorId(1)))
+        val today = clock.fixed.toLocalDate()
+        eventRepo.save(Event(type=EventType.SERVICE, description=null, dateStart=today.atStartOfDay(), recurrence=null, status=Status.PENDING, petId=pet.id!!))
+        eventRepo.save(Event(type=EventType.SERVICE, description=null, dateStart=today.minusDays(1).atStartOfDay(), recurrence=null, status=Status.PENDING, petId=pet.id!!))
+        eventRepo.save(Event(type=EventType.SERVICE, description=null, dateStart=today.atStartOfDay(), recurrence=null, status=Status.DONE, petId=pet.id!!))
+
+        service.sendRemindersForToday()
+
+        assertEquals(1, notifier.notified.size)
+        assertEquals(Status.PENDING, notifier.notified.first().status)
+        assertEquals(today, notifier.notified.first().dateStart.toLocalDate())
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/PetAppServiceTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/PetAppServiceTest.kt
@@ -1,0 +1,66 @@
+package dev.vilquer.petcarescheduler.application.service
+
+import dev.vilquer.petcarescheduler.application.*
+import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.usecase.command.*
+import dev.vilquer.petcarescheduler.usecase.result.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PetAppServiceTest {
+
+    private val petRepo = InMemoryPetRepo()
+    private val tutorRepo = InMemoryTutorRepo()
+    private val service = PetAppService(petRepo, tutorRepo)
+
+    @Test
+    fun `createPet should throw when tutor is missing`() {
+        val cmd = CreatePetCommand("Rex", "Dog", null, LocalDate.now(), TutorId(1))
+        assertThrows(IllegalArgumentException::class.java) { service.createPet(cmd) }
+    }
+
+    @Test
+    fun `createPet saves pet and returns id`() {
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val cmd = CreatePetCommand("Rex", "Dog", "Labrador", LocalDate.now(), tutor.id!!)
+        val result = service.createPet(cmd)
+        assertNotNull(result.petId)
+        val saved = petRepo.findById(result.petId)!!
+        assertEquals("Rex", saved.name)
+    }
+
+    @Test
+    fun `updatePet modifies existing pet`() {
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val saved = petRepo.save(Pet(name="Rex", specie="Dog", race="mix", birthdate=LocalDate.now(), tutorId=tutor.id!!))
+        val cmd = UpdatePetCommand(saved.id!!, name="Bidu", race=null, birthdate=null)
+        val detail = service.updatePet(cmd)
+        assertEquals("Bidu", detail.name)
+    }
+
+    @Test
+    fun `listPets returns paginated result`() {
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        petRepo.save(Pet(name="P1", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
+        val page = service.listPets(0, 10)
+        assertEquals(1, page.total)
+        assertEquals(1, page.items.size)
+    }
+
+    @Test
+    fun `deletePet removes pet`() {
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val saved = petRepo.save(Pet(name="Rex", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
+        service.deletePet(DeletePetCommand(saved.id!!))
+        assertNull(petRepo.findById(saved.id!!))
+    }
+
+    @Test
+    fun `getPet returns detail`() {
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val saved = petRepo.save(Pet(name="Rex", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
+        val detail = service.getPet(saved.id!!)
+        assertEquals(saved.id, detail.id)
+    }
+}

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/TutorAppServiceTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/TutorAppServiceTest.kt
@@ -1,0 +1,51 @@
+package dev.vilquer.petcarescheduler.application.service
+
+import dev.vilquer.petcarescheduler.application.*
+import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.usecase.command.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TutorAppServiceTest {
+
+    private val tutorRepo = InMemoryTutorRepo()
+    private val service = TutorAppService(tutorRepo)
+
+    @Test
+    fun `createTutor persists and returns id`() {
+        val cmd = CreateTutorCommand("Ana", null, "ana@ex.com", "pwd", "1", null)
+        val result = service.createTutor(cmd)
+        assertNotNull(result.tutorId)
+        assertEquals(1, tutorRepo.countAll())
+    }
+
+    @Test
+    fun `updateTutor modifies existing tutor`() {
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val cmd = UpdateTutorCommand(saved.id!!, firstName="Maria", lastName=null, phoneNumber=null, avatar=null)
+        val detail = service.updateTutor(cmd)
+        assertEquals("Maria", detail.firstName)
+    }
+
+    @Test
+    fun `listTutors returns data`() {
+        tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val page = service.listTutors(0, 10)
+        assertEquals(1, page.total)
+        assertEquals(1, page.items.size)
+    }
+
+    @Test
+    fun `deleteTutor removes tutor`() {
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        service.deleteTutor(DeleteTutorCommand(saved.id!!))
+        assertEquals(0, tutorRepo.countAll())
+    }
+
+    @Test
+    fun `getTutor returns detail`() {
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val detail = service.getTutor(saved.id!!)
+        assertEquals(saved.id, detail.id)
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory adapters and clock helpers for testing
- create unit tests for EventAppService, PetAppService, TutorAppService
- test REST controllers and scheduler wiring

## Testing
- `./gradlew test` *(fails: unable to download gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68733590c74083329bbc031a4515ce6a