### PR TITLE
add: implement Email and PhoneNumber value classes to improve consistency

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-security")
+    //implementation("org.springframework.boot:spring-boot-starter-security")
 
 
     implementation("org.mapstruct:mapstruct:1.6.3")

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/EventController.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/EventController.kt
@@ -2,6 +2,8 @@ package dev.vilquer.petcarescheduler.application.adapter.input.rest
 
 import dev.vilquer.petcarescheduler.application.mapper.EventDtoMapper
 import dev.vilquer.petcarescheduler.application.service.EventAppService
+import dev.vilquer.petcarescheduler.core.domain.entity.EventId
+import dev.vilquer.petcarescheduler.usecase.command.DeleteEventCommand
 import dev.vilquer.petcarescheduler.usecase.result.EventRegisteredResult
 import org.springframework.http.*
 import org.springframework.web.bind.annotation.*
@@ -16,4 +18,9 @@ class EventController(
     fun register(@RequestBody dto: EventDtoMapper.RegisterRequest): ResponseEntity<EventRegisteredResult> =
         ResponseEntity.status(HttpStatus.CREATED)
             .body(eventService.registerEvent(mapper.toRegisterCommand(dto)))
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) =
+        eventService.deleteEvent(DeleteEventCommand(EventId(id)))
 }

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorController.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorController.kt
@@ -2,6 +2,8 @@ package dev.vilquer.petcarescheduler.application.adapter.input.rest
 
 import dev.vilquer.petcarescheduler.application.mapper.TutorDtoMapper
 import dev.vilquer.petcarescheduler.application.service.TutorAppService
+import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.usecase.command.DeleteTutorCommand
 import dev.vilquer.petcarescheduler.usecase.result.*
 import org.springframework.http.*
 import org.springframework.web.bind.annotation.*
@@ -23,4 +25,16 @@ class TutorController(
     fun list(@RequestParam page: Int = 0,
              @RequestParam size: Int = 20): TutorsPageResult =
         tutorService.listTutors(page, size)
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @RequestBody dto: TutorDtoMapper.UpdateRequest
+    ): TutorDetailResult =
+        mapper.toUpdateCommand(id, dto).let(tutorService::updateTutor)
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) =
+        tutorService.deleteTutor(DeleteTutorCommand(TutorId(id)))
 }

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/JacksonVoModule.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/JacksonVoModule.kt
@@ -1,0 +1,57 @@
+package dev.vilquer.petcarescheduler.application.config
+
+import com.fasterxml.jackson.core.*
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class JacksonVoModule {
+
+    @Bean
+    open fun voModule(): Module = SimpleModule().apply {
+
+        /* ---- Email ---- */
+        addSerializer(
+            Email::class.java,
+            object : JsonSerializer<Email>() {
+                override fun serialize(
+                    value: Email,
+                    gen: JsonGenerator,
+                    serializers: SerializerProvider
+                ) {
+                    gen.writeString(value.value)
+                }
+            }
+        )
+
+        addDeserializer(
+            Email::class.java,
+            object : JsonDeserializer<Email>() {
+                override fun deserialize(
+                    p: JsonParser,
+                    ctxt: DeserializationContext
+                ): Email =
+                    Email.of(p.text).getOrThrow()
+            }
+        )
+
+        /* ---- PhoneNumber ---- */
+        addSerializer(PhoneNumber::class.java, ToStringSerializer.instance)
+
+        addDeserializer(
+            PhoneNumber::class.java,
+            object : JsonDeserializer<PhoneNumber>() {
+                override fun deserialize(
+                    p: JsonParser,
+                    ctxt: DeserializationContext
+                ): PhoneNumber =
+                    PhoneNumber.of(p.text).getOrThrow()
+            }
+        )
+    }
+}

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/SecurityConfig.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/SecurityConfig.kt
@@ -1,29 +1,29 @@
-package dev.vilquer.petcarescheduler.application.config
-
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.web.SecurityFilterChain
-
-@Configuration
-open class SecurityConfig {
-
-    @Bean
-    open fun filterChain(http: HttpSecurity): SecurityFilterChain {
-        http
-            .csrf { it.ignoringRequestMatchers(PathRequest.toH2Console()) }
-            .authorizeHttpRequests { auth ->
-                auth
-                    .requestMatchers(PathRequest.toH2Console()).permitAll()
-                    .requestMatchers("/tutores", "/login").permitAll()
-                    .anyRequest().authenticated()
-            }
-            .headers { headers ->
-                headers.frameOptions { it.sameOrigin() }
-            }
-            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-        return http.build()
-    }
-}
+//package dev.vilquer.petcarescheduler.application.config
+//
+//import org.springframework.boot.autoconfigure.security.servlet.PathRequest
+//import org.springframework.context.annotation.Bean
+//import org.springframework.context.annotation.Configuration
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity
+//import org.springframework.security.config.http.SessionCreationPolicy
+//import org.springframework.security.web.SecurityFilterChain
+//
+//@Configuration
+//open class SecurityConfig {
+//
+//    @Bean
+//    open fun filterChain(http: HttpSecurity): SecurityFilterChain {
+//        http
+//            .csrf { it.ignoringRequestMatchers(PathRequest.toH2Console()) }
+//            .authorizeHttpRequests { auth ->
+//                auth
+//                    .requestMatchers(PathRequest.toH2Console()).permitAll()
+//                    .requestMatchers("/tutores", "/login").permitAll()
+//                    .anyRequest().authenticated()
+//            }
+//            .headers { headers ->
+//                headers.frameOptions { it.sameOrigin() }
+//            }
+//            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+//        return http.build()
+//    }
+//}

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/mapper/ResultMapper.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/mapper/ResultMapper.kt
@@ -32,8 +32,8 @@ fun Tutor.toDetailResult(): TutorDetailResult = TutorDetailResult(
     id = id!!,
     firstName = firstName,
     lastName = lastName,
-    email = email,
-    phoneNumber = phoneNumber,
+    email = email.value,
+    phoneNumber = phoneNumber?.e164,
     avatar = avatar,
     pets = pets.map { pet ->
         TutorDetailResult.PetInfo(

--- a/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/mapper/TutorDtoMapper.kt
+++ b/application/src/main/kotlin/dev/vilquer/petcarescheduler/application/mapper/TutorDtoMapper.kt
@@ -1,6 +1,8 @@
 package dev.vilquer.petcarescheduler.application.mapper
 
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.usecase.command.*
 import org.springframework.stereotype.Component
 
@@ -29,9 +31,9 @@ class TutorDtoMapper {
         CreateTutorCommand(
             firstName   = dto.firstName,
             lastName    = dto.lastName,
-            email       = dto.email,
+            email       = Email.of(dto.email).getOrThrow(),
             rawPassword = dto.rawPassword,
-            phoneNumber = dto.phoneNumber,
+            phoneNumber = PhoneNumber.of(dto.phoneNumber).getOrThrow(),
             avatar      = dto.avatar
         )
 
@@ -40,7 +42,7 @@ class TutorDtoMapper {
             tutorId     = TutorId(id),
             firstName   = dto.firstName,
             lastName    = dto.lastName,
-            phoneNumber = dto.phoneNumber,
+            phoneNumber = dto.phoneNumber?.let { PhoneNumber.of(it).getOrThrow() },
             avatar      = dto.avatar
         )
 }

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorControllerTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorControllerTest.kt
@@ -1,9 +1,11 @@
 package dev.vilquer.petcarescheduler.application.adapter.input.rest
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import dev.vilquer.petcarescheduler.application.config.JacksonVoModule
 import dev.vilquer.petcarescheduler.application.mapper.TutorDtoMapper
 import dev.vilquer.petcarescheduler.application.service.TutorAppService
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
 import dev.vilquer.petcarescheduler.usecase.result.TutorCreatedResult
 import dev.vilquer.petcarescheduler.usecase.result.TutorSummary
 import dev.vilquer.petcarescheduler.usecase.result.TutorsPageResult
@@ -19,9 +21,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 class TutorControllerTest {
 
     private val service: TutorAppService = mock()
-    private val mapper = TutorDtoMapper()         // classe concreta
+    private val mapper = TutorDtoMapper()
     private lateinit var mvc: MockMvc
     private val objectMapper = jacksonObjectMapper()
+        .registerModule(
+            JacksonVoModule().voModule()
+        )
 
     @BeforeEach
     fun setup() {
@@ -40,24 +45,23 @@ class TutorControllerTest {
             lastName    = null,
             email       = "a@e.com",
             rawPassword = "pwd",
-            phoneNumber = "1",
+            phoneNumber = "(11) 99876-5432",
             avatar      = null
         )
 
-        mvc.perform(
-            post("/api/v1/tutors")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(req))
-        )
+        mvc.perform(post("/api/v1/tutors")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(req)))
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.tutorId").value(1))
+        verify(service).createTutor(any())
     }
 
     @Test
     fun `list tutors returns page`() {
         val page = TutorsPageResult(
             items = listOf(
-                TutorSummary(TutorId(1),"Ana","a@e.com",0)
+                TutorSummary(TutorId(1),"Ana",Email.of("a@e.com").getOrThrow(),0)
             ),
             total = 1, page = 0, size = 20
         )

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/PetAppServiceTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/PetAppServiceTest.kt
@@ -2,6 +2,8 @@ package dev.vilquer.petcarescheduler.application.service
 
 import dev.vilquer.petcarescheduler.application.*
 import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.usecase.command.*
 import dev.vilquer.petcarescheduler.usecase.result.*
 import org.junit.jupiter.api.Assertions.*
@@ -22,7 +24,7 @@ class PetAppServiceTest {
 
     @Test
     fun `createPet saves pet and returns id`() {
-        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email=Email.of("e@x.com").getOrThrow(), passwordHash="p", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val cmd = CreatePetCommand("Rex", "Dog", "Labrador", LocalDate.now(), tutor.id!!)
         val result = service.createPet(cmd)
         assertNotNull(result.petId)
@@ -32,7 +34,7 @@ class PetAppServiceTest {
 
     @Test
     fun `updatePet modifies existing pet`() {
-        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email=Email.of("e@x.com").getOrThrow(), passwordHash="p", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val saved = petRepo.save(Pet(name="Rex", specie="Dog", race="mix", birthdate=LocalDate.now(), tutorId=tutor.id!!))
         val cmd = UpdatePetCommand(saved.id!!, name="Bidu", race=null, birthdate=null)
         val detail = service.updatePet(cmd)
@@ -41,7 +43,7 @@ class PetAppServiceTest {
 
     @Test
     fun `listPets returns paginated result`() {
-        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email=Email.of("e@x.com").getOrThrow(), passwordHash="p", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         petRepo.save(Pet(name="P1", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
         val page = service.listPets(0, 10)
         assertEquals(1, page.total)
@@ -50,7 +52,7 @@ class PetAppServiceTest {
 
     @Test
     fun `deletePet removes pet`() {
-        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email=Email.of("e@x.com").getOrThrow(), passwordHash="p", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val saved = petRepo.save(Pet(name="Rex", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
         service.deletePet(DeletePetCommand(saved.id!!))
         assertNull(petRepo.findById(saved.id!!))
@@ -58,7 +60,7 @@ class PetAppServiceTest {
 
     @Test
     fun `getPet returns detail`() {
-        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email="e", passwordHash="p", phoneNumber="1"))
+        val tutor = tutorRepo.save(Tutor(firstName="A", lastName=null, email=Email.of("e@x.com").getOrThrow(), passwordHash="p", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val saved = petRepo.save(Pet(name="Rex", specie="Dog", race=null, birthdate=LocalDate.now(), tutorId=tutor.id!!))
         val detail = service.getPet(saved.id!!)
         assertEquals(saved.id, detail.id)

--- a/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/TutorAppServiceTest.kt
+++ b/application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/TutorAppServiceTest.kt
@@ -2,6 +2,8 @@ package dev.vilquer.petcarescheduler.application.service
 
 import dev.vilquer.petcarescheduler.application.*
 import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.usecase.command.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -13,15 +15,14 @@ class TutorAppServiceTest {
 
     @Test
     fun `createTutor persists and returns id`() {
-        val cmd = CreateTutorCommand("Ana", null, "ana@ex.com", "pwd", "1", null)
+        val cmd = CreateTutorCommand("Ana", null, Email.of("ana@ex.com").getOrThrow(), "pwd", PhoneNumber.of("+5511912345678").getOrNull(), null)
         val result = service.createTutor(cmd)
         assertNotNull(result.tutorId)
         assertEquals(1, tutorRepo.countAll())
     }
-
     @Test
     fun `updateTutor modifies existing tutor`() {
-        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email=Email.of("a@e.com").getOrThrow(), passwordHash="h", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val cmd = UpdateTutorCommand(saved.id!!, firstName="Maria", lastName=null, phoneNumber=null, avatar=null)
         val detail = service.updateTutor(cmd)
         assertEquals("Maria", detail.firstName)
@@ -29,7 +30,7 @@ class TutorAppServiceTest {
 
     @Test
     fun `listTutors returns data`() {
-        tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        tutorRepo.save(Tutor(firstName="Ana", lastName=null, email=Email.of("a@e.com").getOrThrow(), passwordHash="h", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val page = service.listTutors(0, 10)
         assertEquals(1, page.total)
         assertEquals(1, page.items.size)
@@ -37,14 +38,14 @@ class TutorAppServiceTest {
 
     @Test
     fun `deleteTutor removes tutor`() {
-        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email=Email.of("a@e.com").getOrThrow(), passwordHash="h", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         service.deleteTutor(DeleteTutorCommand(saved.id!!))
         assertEquals(0, tutorRepo.countAll())
     }
 
     @Test
     fun `getTutor returns detail`() {
-        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email="a@e.com", passwordHash="h", phoneNumber="1"))
+        val saved = tutorRepo.save(Tutor(firstName="Ana", lastName=null, email=Email.of("a@e.com").getOrThrow(), passwordHash="h", phoneNumber=PhoneNumber.of("+5511912345678").getOrNull()))
         val detail = service.getTutor(saved.id!!)
         assertEquals(saved.id, detail.id)
     }

--- a/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/entity/Tutor.kt
+++ b/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/entity/Tutor.kt
@@ -1,12 +1,15 @@
 package dev.vilquer.petcarescheduler.core.domain.entity
 
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
+
 data class Tutor(
     val id: TutorId? = null,
     val firstName: String,
     val lastName: String?,
-    val email: String,
+    val email: Email,
     val passwordHash: String,
-    val phoneNumber: String,
+    val phoneNumber: PhoneNumber? = null,
     val avatar: String? = null,
     val pets: List<Pet> = mutableListOf()
 )

--- a/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/valueobject/Email.kt
+++ b/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/valueobject/Email.kt
@@ -1,0 +1,21 @@
+package dev.vilquer.petcarescheduler.core.domain.valueobject
+
+@JvmInline
+value class Email private constructor(val value: String) {
+
+    companion object {
+        /** Regex RFC 5322 simplificada */
+        private val REGEX =
+            Regex("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$", RegexOption.IGNORE_CASE)
+
+        /** Devolve Result para evitar lançar exceção em regra de domínio. */
+        fun of(raw: String): Result<Email> =
+            if (REGEX.matches(raw.trim()))
+                Result.success(Email(raw.trim().lowercase()))
+            else
+                Result.failure(IllegalArgumentException("Invalid email: $raw"))
+    }
+
+    override fun toString() = value
+}
+

--- a/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/valueobject/PhoneNumber.kt
+++ b/core/src/main/kotlin/dev/vilquer/petcarescheduler/core/domain/valueobject/PhoneNumber.kt
@@ -1,0 +1,55 @@
+package dev.vilquer.petcarescheduler.core.domain.valueobject
+
+import kotlin.Result
+
+@JvmInline
+value class PhoneNumber private constructor(val e164: String) {
+
+    companion object {
+        /**
+         * Regex para validar números de telefone.
+         * - `^`: Início da string.
+         * - `(\+)?`: Um ou nenhum caractere '+' (para o código do país).
+         * - `[\d\s().-]{8,17}`: De 8 a 17 caracteres, que podem ser dígitos, espaços, parênteses ou hífens.
+         * - Mínimo de 8 para números locais curtos e máximo de 17 para formatos internacionais completos.
+         * - `$`: Fim da string.
+         */
+        private val PHONE_NUMBER_REGEX = Regex("""^(\+)?[\d\s().-]{8,17}$""")
+
+        fun of(raw: String): Result<PhoneNumber> {
+            val cleaned = raw.trim()
+
+            if (!PHONE_NUMBER_REGEX.matches(cleaned)) {
+                return Result.failure(IllegalArgumentException("Invalid phone number format: $raw"))
+            }
+
+            // Normaliza o número removendo tudo exceto dígitos e o '+' inicial
+            val normalized = normalize(cleaned)
+
+
+            return if (normalized.length >= 10) { // Validação de comprimento mínimo (ex: 2 dígitos DDD + 8 dígitos número)
+                Result.success(PhoneNumber(normalized))
+            } else {
+                Result.failure(IllegalArgumentException("Invalid phone number length: $raw"))
+            }
+        }
+        private fun normalize(raw: String): String {
+            // Remove caracteres de formatação
+            val numericString = raw.filter { it.isDigit() }
+
+            // Se o número original já tiver o DDI, use-o
+            if (raw.startsWith("+")) {
+                return "+$numericString"
+            }
+
+            // Se for um número brasileiro (com DDD), adiciona o DDI do Brasil
+            if (numericString.length == 10 || numericString.length == 11) {
+                return "+55$numericString"
+            }
+
+            return numericString
+        }
+    }
+    override fun toString() = e164
+}
+

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
     implementation("org.flywaydb:flyway-core")
     implementation("org.postgresql:postgresql")

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/ClockAdapter.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/ClockAdapter.kt
@@ -1,4 +1,4 @@
-package dev.vilquer.petcarescheduler.dev.vilquer.petcarescheduler.infra.adapter.output.external
+package dev.vilquer.petcarescheduler.infra.adapter.output.external
 
 import dev.vilquer.petcarescheduler.usecase.contract.drivenports.ClockPort
 import org.springframework.stereotype.Component

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/EventRepositoryAdapter.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/EventRepositoryAdapter.kt
@@ -1,4 +1,4 @@
-package dev.vilquer.petcarescheduler.dev.vilquer.petcarescheduler.infra.adapter.output.external
+package dev.vilquer.petcarescheduler.infra.adapter.output.external
 
 import dev.vilquer.petcarescheduler.core.domain.entity.Event
 import dev.vilquer.petcarescheduler.core.domain.entity.EventId

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/PetRepositoryAdapter.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/PetRepositoryAdapter.kt
@@ -1,4 +1,4 @@
-package dev.vilquer.petcarescheduler.dev.vilquer.petcarescheduler.infra.adapter.output.external
+package dev.vilquer.petcarescheduler.infra.adapter.output.external
 
 import dev.vilquer.petcarescheduler.usecase.contract.drivenports.PetRepositoryPort
 import dev.vilquer.petcarescheduler.core.domain.entity.*

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/TutorRepositoryAdapter.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/external/TutorRepositoryAdapter.kt
@@ -1,4 +1,4 @@
-package dev.vilquer.petcarescheduler.dev.vilquer.petcarescheduler.infra.adapter.output.external
+package dev.vilquer.petcarescheduler.infra.adapter.output.external
 
 import dev.vilquer.petcarescheduler.core.domain.entity.Tutor
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId

--- a/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/persistence/jpa/entity/TutorJpa.kt
+++ b/infra/src/main/kotlin/dev/vilquer/petcarescheduler/infra/adapter/output/persistence/jpa/entity/TutorJpa.kt
@@ -1,6 +1,8 @@
 package dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity
 
 
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import jakarta.persistence.*
 
 @Entity
@@ -17,13 +19,13 @@ class TutorJpa {
     var lastName: String? = null
 
     @Column(nullable = false, unique = true)
-    lateinit var email: String
+    var email: Email = Email.of("placeholder@example.com").getOrThrow()
 
     @Column(nullable = false)
     lateinit var passwordHash: String
 
     @Column(nullable = false)
-    lateinit var phoneNumber: String
+    var phoneNumber: PhoneNumber? = null
 
     var avatar: String? = null
 

--- a/infra/src/test/kotlin/EventMapperIntegrationTest.kt
+++ b/infra/src/test/kotlin/EventMapperIntegrationTest.kt
@@ -5,6 +5,8 @@ import dev.vilquer.petcarescheduler.core.domain.entity.Event
 import dev.vilquer.petcarescheduler.core.domain.entity.PetId
 import dev.vilquer.petcarescheduler.core.domain.entity.Status
 import dev.vilquer.petcarescheduler.core.domain.entity.EventType
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity.PetJpa
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity.TutorJpa
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.mappers.EventMapper
@@ -41,9 +43,9 @@ class EventMapperIntegrationTest {
         // Create and save test tutor
         val tutor = TutorJpa().apply {
             firstName = "Ana"
-            email = "ana@ex.com"
+            email = Email.of("ana@ex.com").getOrThrow()
             passwordHash = "pwd"
-            phoneNumber = "1198888-1111"
+            phoneNumber = PhoneNumber.of("1198888-1111").getOrNull()
         }
         tutorRepository.save(tutor)
 

--- a/infra/src/test/kotlin/PetRepositoryIntegrationTest.kt
+++ b/infra/src/test/kotlin/PetRepositoryIntegrationTest.kt
@@ -3,6 +3,8 @@ package petcarescheduler.infra.test
 import dev.vilquer.petcarescheduler.PetCareSchedulerApplication
 import dev.vilquer.petcarescheduler.core.domain.entity.Pet
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity.TutorJpa
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.mappers.PetMapper
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.repository.PetJpaRepository
@@ -29,9 +31,9 @@ class PetRepositoryIntegrationTest {
         // 1) Cria e persiste um tutor
         val tutorJpa = TutorJpa().apply {
             firstName = "Ana"
-            email = "ana@ex.com"
+            email = Email.of("ana@ex.com").getOrThrow()
             passwordHash = "hash"
-            phoneNumber = "1234"
+            phoneNumber = PhoneNumber.of("1198888-1111").getOrNull()
         }
         tutorRepoJpa.save(tutorJpa)
 

--- a/infra/src/test/kotlin/TutorMapperIntegrationTest.kt
+++ b/infra/src/test/kotlin/TutorMapperIntegrationTest.kt
@@ -6,6 +6,8 @@ import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.reposit
 import dev.vilquer.petcarescheduler.core.domain.entity.Pet
 import dev.vilquer.petcarescheduler.core.domain.entity.Tutor
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -38,9 +40,9 @@ class TutorMapperIntegrationTest {
             id = TutorId(1),
             firstName = "Carlos",
             lastName = "Mendes",
-            email = "carlos@ex.com",
+            email = Email.of("carlos@ex.com").getOrThrow(),
             passwordHash = "hash123",
-            phoneNumber = "1199999-0000",
+            phoneNumber = PhoneNumber.of("1199999-0000").getOrNull(),
             avatar = null,
             pets = listOf(
                 Pet(

--- a/infra/src/test/kotlin/TutorMapperTest.kt
+++ b/infra/src/test/kotlin/TutorMapperTest.kt
@@ -4,6 +4,8 @@ import dev.vilquer.petcarescheduler.core.domain.entity.Pet
 import dev.vilquer.petcarescheduler.core.domain.entity.PetId
 import dev.vilquer.petcarescheduler.core.domain.entity.Tutor
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity.PetJpa
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.entity.TutorJpa
 import dev.vilquer.petcarescheduler.infra.adapter.output.persistence.jpa.mappers.TutorMapper
@@ -34,9 +36,9 @@ class TutorMapperTest {
             assertEquals(TutorId(TUTOR_ID), id)
             assertEquals("Carlos", firstName)
             assertEquals("Silva", lastName)
-            assertEquals("carlos@ex.com", email)
+            assertEquals("carlos@ex.com", email.toString())
             assertEquals("abc123", passwordHash)
-            assertEquals("99999-0000", phoneNumber)
+            assertEquals(PhoneNumber.of("55599990000").getOrNull(), phoneNumber)
             assertEquals("avatar.png", avatar)
 
             // Pets assertions
@@ -65,9 +67,9 @@ class TutorMapperTest {
             assertNull(id)
             assertEquals("Mariana", firstName)
             assertEquals("Costa", lastName)
-            assertEquals("mari@ex.com", email)
+            assertEquals("mari@ex.com", email.toString())
             assertEquals("senhaX", passwordHash)
-            assertEquals("88888-1111", phoneNumber)
+            assertEquals(PhoneNumber.of("55588881111").getOrNull(), phoneNumber)
             assertNull(avatar)
 
             // Pets assertions
@@ -97,9 +99,9 @@ class TutorMapperTest {
             assertEquals(5L, id)
             assertEquals("Ana Paula", firstName)
             assertEquals("Lima", lastName)
-            assertEquals("ana.paula@ex.com", email)
+            assertEquals("ana.paula@ex.com", email.toString())
             assertEquals("newHash", passwordHash)
-            assertEquals("77777-3333", phoneNumber)
+            assertEquals(PhoneNumber.of("55577773333").getOrNull(), phoneNumber)
             assertEquals("new.png", avatar)
 
             // Pets assertions
@@ -124,9 +126,9 @@ class TutorMapperTest {
             id = TUTOR_ID
             firstName = "Carlos"
             lastName = "Silva"
-            email = "carlos@ex.com"
+            email = Email.of("carlos@ex.com").getOrThrow()
             passwordHash = "abc123"
-            phoneNumber = "99999-0000"
+            phoneNumber = PhoneNumber.of("55599990000").getOrNull()
             avatar = "avatar.png"
         }
 
@@ -147,9 +149,9 @@ class TutorMapperTest {
             id = null,
             firstName = "Mariana",
             lastName = "Costa",
-            email = "mari@ex.com",
+            email = Email.of("mari@ex.com").getOrThrow(),
             passwordHash = "senhaX",
-            phoneNumber = "88888-1111",
+            phoneNumber = PhoneNumber.of("55588881111").getOrNull(),
             avatar = null,
             pets = listOf(
                 Pet(
@@ -169,9 +171,9 @@ class TutorMapperTest {
             id = 5
             firstName = "Ana"
             lastName = "Lima"
-            email = "ana@ex.com"
+            email = Email.of("ana@ex.com").getOrThrow()
             passwordHash = "oldHash"
-            phoneNumber = "77777-2222"
+            phoneNumber = PhoneNumber.of("55577772222").getOrNull()
             avatar = "old.png"
 
             pets.add(PetJpa().apply {
@@ -189,9 +191,9 @@ class TutorMapperTest {
             id = TutorId(5),
             firstName = "Ana Paula",
             lastName = "Lima",
-            email = "ana.paula@ex.com",
+            email = Email.of("ana.paula@ex.com").getOrThrow(),
             passwordHash = "newHash",
-            phoneNumber = "77777-3333",
+            phoneNumber = PhoneNumber.of("55577773333").getOrNull(),
             avatar = "new.png",
             pets = listOf(
                 Pet(

--- a/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/command/CreateTutorCommand.kt
+++ b/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/command/CreateTutorCommand.kt
@@ -1,10 +1,13 @@
 package dev.vilquer.petcarescheduler.usecase.command
 
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
+
 data class CreateTutorCommand(
     val firstName: String,
     val lastName: String?,
-    val email: String,
+    val email: Email,
     val rawPassword: String,
-    val phoneNumber: String,
+    val phoneNumber: PhoneNumber?,
     val avatar: String? = null
 )

--- a/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/command/UpdateTutorCommand.kt
+++ b/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/command/UpdateTutorCommand.kt
@@ -1,11 +1,12 @@
 package dev.vilquer.petcarescheduler.usecase.command
 
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 
 data class UpdateTutorCommand(
     val tutorId: TutorId,
     val firstName: String? = null,
     val lastName: String? = null,
-    val phoneNumber: String? = null,
+    val phoneNumber: PhoneNumber? = null,
     val avatar: String? = null
 )

--- a/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/result/TutorDetailResult.kt
+++ b/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/result/TutorDetailResult.kt
@@ -8,7 +8,7 @@ data class TutorDetailResult(
     val firstName: String,
     val lastName: String?,
     val email: String,
-    val phoneNumber: String,
+    val phoneNumber: String?,
     val avatar: String?,
     val pets: List<PetInfo>
 ) {

--- a/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/result/TutorSummary.kt
+++ b/usecase/src/main/kotlin/dev/vilquer/petcarescheduler/usecase/result/TutorSummary.kt
@@ -1,10 +1,11 @@
 package dev.vilquer.petcarescheduler.usecase.result
 
 import dev.vilquer.petcarescheduler.core.domain.entity.TutorId
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
 
 data class TutorSummary(
     val id: TutorId,
     val fullName: String,
-    val email: String,
+    val email: Email,
     val petsCount: Int
 )

--- a/usecase/src/test/kotlin/dev/vilquer/petcarescheduler/usecase/ResultMappingTest.kt
+++ b/usecase/src/test/kotlin/dev/vilquer/petcarescheduler/usecase/ResultMappingTest.kt
@@ -1,4 +1,6 @@
 import dev.vilquer.petcarescheduler.core.domain.entity.*
+import dev.vilquer.petcarescheduler.core.domain.valueobject.Email
+import dev.vilquer.petcarescheduler.core.domain.valueobject.PhoneNumber
 import dev.vilquer.petcarescheduler.usecase.result.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -25,8 +27,8 @@ class ResultMappingTest {
         id = id!!,
         firstName = firstName,
         lastName = lastName,
-        email = email,
-        phoneNumber = phoneNumber,
+        email = email.value,
+        phoneNumber = phoneNumber.toString(),
         avatar = avatar,
         pets = pets.map { p ->
             TutorDetailResult.PetInfo(p.id!!, p.name, p.specie)
@@ -67,9 +69,9 @@ class ResultMappingTest {
             id = TutorId(5L),
             firstName = "Ana",
             lastName = "Silva",
-            email = "ana@ex.com",
+            email = Email.of("ana@ex.com").getOrThrow(),
             passwordHash = "hash",
-            phoneNumber = "1111",
+            phoneNumber = PhoneNumber.of("1111").getOrNull(),
             avatar = null,
             pets = listOf(
                 Pet(


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of domain-specific value objects (`Email` and `PhoneNumber`), enhances REST controllers with additional functionality, and updates test cases to align with the new domain model. Security-related code has been commented out, reflecting a temporary or planned removal of security configurations.

### Enhancements to domain-specific value objects:
* [`application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/JacksonVoModule.kt`](diffhunk://#diff-d61f8f6c16bc140f234a181f894f45555bd4b9e34e5ec3d005a4e53692724126R1-R57): Added custom serializers and deserializers for `Email` and `PhoneNumber` to ensure proper JSON handling.
* [`application/src/main/kotlin/dev/vilquer/petcarescheduler/application/mapper/TutorDtoMapper.kt`](diffhunk://#diff-85a313e5a5aae8b27719a09bcefe9aa369dc8266c5de4a88cdfe72cfdc6b1082L32-R36): Updated `TutorDtoMapper` to use `Email.of` and `PhoneNumber.of` for creating commands, ensuring validation and consistency. [[1]](diffhunk://#diff-85a313e5a5aae8b27719a09bcefe9aa369dc8266c5de4a88cdfe72cfdc6b1082L32-R36) [[2]](diffhunk://#diff-85a313e5a5aae8b27719a09bcefe9aa369dc8266c5de4a88cdfe72cfdc6b1082L43-R45)

### REST controller improvements:
* [`application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/EventController.kt`](diffhunk://#diff-1437433a2f9d605c0d56a38cc5d41eace2e8ecff30639d9e2640d2899ee4fee9R21-R25): Added a `DELETE` endpoint to remove events by ID.
* [`application/src/main/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorController.kt`](diffhunk://#diff-8b1e2f9629cbcb180a1e8af7c66cab1d980882b55742990616e5d0af62f63f78R28-R39): Added `PUT` and `DELETE` endpoints for updating and removing tutors by ID.

### Updates to test cases:
* [`application/src/test/kotlin/dev/vilquer/petcarescheduler/application/adapter/input/rest/TutorControllerTest.kt`](diffhunk://#diff-fc5d3553af27845cd9b41b96b50a515958c847176193bbf0db731458b894f134L22-R29): Registered `JacksonVoModule` in `ObjectMapper` for testing and updated test cases to use `Email` and `PhoneNumber` objects. [[1]](diffhunk://#diff-fc5d3553af27845cd9b41b96b50a515958c847176193bbf0db731458b894f134L22-R29) [[2]](diffhunk://#diff-fc5d3553af27845cd9b41b96b50a515958c847176193bbf0db731458b894f134L43-R64)
* [`application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/PetAppServiceTest.kt`](diffhunk://#diff-bc38001237e0ebca3f1c243bb0013b0538e468e2536231b8a5963265d126a8a8L25-R27): Modified test cases to use `Email` and `PhoneNumber` objects for tutor creation and validation. [[1]](diffhunk://#diff-bc38001237e0ebca3f1c243bb0013b0538e468e2536231b8a5963265d126a8a8L25-R27) [[2]](diffhunk://#diff-bc38001237e0ebca3f1c243bb0013b0538e468e2536231b8a5963265d126a8a8L53-R63)
* [`application/src/test/kotlin/dev/vilquer/petcarescheduler/application/service/TutorAppServiceTest.kt`](diffhunk://#diff-50269f00a19a87a79a0b3e585678fa49a2a49da515d97789d95ef0c8b9d5bdeeL16-R48): Updated test cases for tutor creation, update, and deletion to use `Email` and `PhoneNumber` objects.

### Security configuration changes:
* [`application/build.gradle.kts`](diffhunk://#diff-c62819285fcc5702ece2c6cdcdf59976df48030ebb72af02d055d2b1679bfe60L24-R24): Commented out the `spring-boot-starter-security` dependency.
* [`application/src/main/kotlin/dev/vilquer/petcarescheduler/application/config/SecurityConfig.kt`](diffhunk://#diff-c911d7d4b774ae9e42ae262a4ed6b67dbb622806f1f91d7e73669027f50d0f25L1-R29): Commented out the entire security configuration class, indicating a temporary or planned removal of security features.